### PR TITLE
Normalize cell array order when reading JPZ files.

### DIFF
--- a/jscrossword/jpz_read_write.js
+++ b/jscrossword/jpz_read_write.js
@@ -183,6 +183,16 @@ function xw_read_jpz(data1) {
         cells.push(new_cell);
     }
 
+    // Normalize cell order to row-major
+    cells.sort((cell_1, cell_2) => {
+      var y_diff = cell_1.y - cell_2.y;
+      if (y_diff != 0) {
+        return y_diff;
+      } else {
+        return cell_1.x - cell_2.x;
+      }
+    });
+
     /** WORDS **/
     var words = [];
     // helper function to get cell values from "x" and "y" strings

--- a/jscrossword/jscrossword_combined.js
+++ b/jscrossword/jscrossword_combined.js
@@ -392,6 +392,16 @@ function xw_read_jpz(data1) {
         cells.push(new_cell);
     }
 
+    // Normalize cell order to row-major
+    cells.sort((cell_1, cell_2) => {
+      var y_diff = cell_1.y - cell_2.y;
+      if (y_diff != 0) {
+        return y_diff;
+      } else {
+        return cell_1.x - cell_2.x;
+      }
+    });
+
     /** WORDS **/
     var words = [];
     // helper function to get cell values from "x" and "y" strings


### PR DESCRIPTION
Fixes issue with Mechapuzzle and (at least) the most recent MGWCC JPZ
file, whose cells are provided in column-major order instead of
row-major order. Without this fix, the cell numbers are rendered in the
grid in the wrong places.