### PR TITLE
Fix a bug for blocks in iPuz files

### DIFF
--- a/jscrossword/index.html
+++ b/jscrossword/index.html
@@ -38,7 +38,7 @@ function handleFileSelect(evt) {
                     //xw = xw_constructor.fromIpuz(contents);
                     console.log(xw);
                     //xw.from(contents);
-                    //jscrossword_to_pdf(xw);
+                    jscrossword_to_pdf(xw);
                     //var jpz_str = xw.toJPZString();
                     //file_download(jpz_str, 'test.jpz', 'text/xml');
                     MY_GLOBAL = xw;

--- a/jscrossword/ipuz_read_write.js
+++ b/jscrossword/ipuz_read_write.js
@@ -67,9 +67,7 @@ function xw_read_ipuz(data) {
                 number = number.toString();
                 if (number === EMPTY) {number = null;}
             }
-            if (number === EMPTY || number === BLOCK || number === 0) {
-                number = null;
-            }
+
             // solution
             var solution = '';
             try {
@@ -83,7 +81,7 @@ function xw_read_ipuz(data) {
             } catch {}
             // type
             var type = null;
-            if (solution === BLOCK) {
+            if (solution === BLOCK || number === BLOCK) {
                 type = 'block';
             } else if (data['puzzle'][y][x] === null) {
                 type = 'void';
@@ -119,6 +117,11 @@ function xw_read_ipuz(data) {
                 // we just read them in as `number` or `top_right_number` for now
                 if (!number) {number = style.mark.BL;}
                 if (!top_right_number) {top_right_number = style.mark.BR;}
+            }
+
+            // Change the "number" if it isn't real
+            if (number === EMPTY || number === BLOCK) {
+                number = null;
             }
 
             var new_cell = {

--- a/jscrossword/jscrossword_combined.js
+++ b/jscrossword/jscrossword_combined.js
@@ -189,9 +189,7 @@ function xw_read_ipuz(data) {
                 number = number.toString();
                 if (number === EMPTY) {number = null;}
             }
-            if (number === EMPTY || number === BLOCK || number === 0) {
-                number = null;
-            }
+
             // solution
             var solution = '';
             try {
@@ -205,7 +203,7 @@ function xw_read_ipuz(data) {
             } catch {}
             // type
             var type = null;
-            if (solution === BLOCK) {
+            if (solution === BLOCK || number === BLOCK) {
                 type = 'block';
             } else if (data['puzzle'][y][x] === null) {
                 type = 'void';
@@ -241,6 +239,11 @@ function xw_read_ipuz(data) {
                 // we just read them in as `number` or `top_right_number` for now
                 if (!number) {number = style.mark.BL;}
                 if (!top_right_number) {top_right_number = style.mark.BR;}
+            }
+
+            // Change the "number" if it isn't real
+            if (number === EMPTY || number === BLOCK) {
+                number = null;
             }
 
             var new_cell = {


### PR DESCRIPTION
It's acceptable to not have a solution in an iPuz file. Prior to this commit we were reading black squares solely from the solution, which is bad. This commit allows us to read them from the grid as well.